### PR TITLE
Updating the background color to keep the button text black

### DIFF
--- a/src/app/cards/shots/shots.component.css
+++ b/src/app/cards/shots/shots.component.css
@@ -15,7 +15,7 @@
 
 .mat-button-toggle {
   border: var(--borderColor);
-  color: var(--bgColor);
+  color: black;
   padding: 0px 5px;
 }
 


### PR DESCRIPTION
<img width="924" alt="image" src="https://github.com/user-attachments/assets/835bbc02-fd10-4e2e-afce-bda2761485db">

References: https://github.com/neilpl24/pierreanalyticsource/issues/58

Updating button text so that it always black. 